### PR TITLE
Add support for Lenovo D1212

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This tool is used to monitor Xyratex JBOD, also known as:
 - Seagate/Xyratex SP-3584
 - Seagate Exos E 4U106
 - Dell MD1420
+- Lenovo D1212
 
 These JBODs are probably also supported with some slight modifications:
 - Dell MD1280


### PR DESCRIPTION
I have D1212 on test before D3284 arrives and I added support for it. I think D3284 should work just by adding the model number.

PSUs output has one more line on D1212 (or it might just be the version of sg tools?), so other array elements are shifted by one index and there is some text infront of fan speed, so anchoring regex is not working.

Most of the max values are also guessed, I can fine tuned them once I get the fully loaded D3284.

Let me know what you think.